### PR TITLE
Fix failing Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
-  - "5.3"
-  - "5.4"
-  - "5.5"
-  - "hhvm"
+  - "5.6"
+  - "7.0"
+  - "7.1"
 
 before_script:
   - curl -s https://getcomposer.org/installer | php && php composer.phar update --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,7 @@ php:
   - "7.1"
 
 before_script:
-  - curl -s https://getcomposer.org/installer | php && php composer.phar update --dev
+  - curl -s https://getcomposer.org/installer | php && php composer.phar update
 
 script:
-  - mkdir -p build/logs
-  - php vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml -c SilMock/tests/phpunit.xml SilMock/tests/
-  
-after_script:
-  - php vendor/bin/coveralls -v
+  - php vendor/bin/phpunit -c SilMock/tests/phpunit.xml SilMock/tests/


### PR DESCRIPTION
The tests were passing for most of the PHP versions we were testing, but an error was happening during code coverage report generation. For now, this is more useful to us just knowing that the tests pass (without code coverage data).