### PR TITLE
Add more API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Properties of a Google Service Directory (GSD) include...
 1. $users, which gets set to a GSD Users_Resource
 2. $users_aliases, which gets set to a GSD UsersAliases_Resource
 3. $asps, which gets set to a GSD Asps_Resource
-3. $tokens, which gets set to a GSD Tokens_Resource
+4. $tokens, which gets set to a GSD Tokens_Resource
 
 ### Users_Resource
 A Users_Resource has various methods for managing Google Apps users.  Three of these

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 google-api-php-client-mock
 ==========================
-[![Travis-CI Build Status](https://api.travis-ci.org/silinternational/google-api-php-client-mock.png?branch=master)](https://travis-ci.org/silinternational/google-api-php-client-mock)
-[![Coverage Status](https://coveralls.io/repos/silinternational/google-api-php-client-mock/badge.png)](https://coveralls.io/r/silinternational/google-api-php-client-mock)
+[![Travis-CI Build Status](https://api.travis-ci.org/silinternational/google-api-php-client-mock.png?branch=develop)](https://travis-ci.org/silinternational/google-api-php-client-mock)
 
-
-A small scale intelligent mock of the Google API PHP Client for unit and functional testing.
+A small scale intelligent mock of the Google API PHP Client for unit and
+functional testing.
 
 Overview
 --------
-This is intended to mock a portion of the Google Services Directory, particularly
-aspects that make calls to an external system relating to users and users aliases.
+This is intended to mock a portion of the Google APIs related to G Suite
+accounts, particularly calls relating to users and users' aliases.
 
-Two primary properties of a Google Service Directory (GSD) are ...
+## Directory
+Properties of a Google Service Directory (GSD) include...
 
 1. $users, which gets set to a GSD Users_Resource
 2. $users_aliases, which gets set to a GSD UsersAliases_Resource
+3. $asps, which gets set to a GSD Asps_Resource
+3. $tokens, which gets set to a GSD Tokens_Resource
 
 ### Users_Resource
 A Users_Resource has various methods for managing Google Apps users.  Three of these
@@ -31,6 +33,46 @@ The ones implemented by this mock are ...
 1. delete()
 2. insert()
 3. listUsersAliases()
+
+### Asps_Resource
+An Asps_Resource is for managing a user's App Specific Passwords (ASPs). This
+mock implements...
+
+1. listAsps()
+
+### Tokens_Resource
+A Tokens_Resource is for managing a user's OAuth access tokens. This mock
+implements...
+
+1. listTokens()
+
+## Gmail
+Properties of the Gmail API object include...
+
+1. $users_settings
+2. $users_settings_delegates
+3. $users_settings_forwardingAddresses
+
+### UsersSettings
+Methods on the UsersSettings resource that this mock implements include...
+
+1. updateImap()
+2. updatePop()
+
+## UsersSettingsDelegates
+Methods on the UsersSettingsDelegates resource that this mock implements
+include...
+
+1. create()
+2. delete()
+3. get()
+4. listUsersSettingsDelegates()
+
+## UsersSettingsForwardingAddresses
+Methods on the UsersSettingsForwardingAddresses resource that this mock
+implements include...
+
+1. listUsersSettingsForwardingAddresses()
 
 Data Persistence
 ----------------

--- a/SilMock/Google/Service/Directory.php
+++ b/SilMock/Google/Service/Directory.php
@@ -1,14 +1,15 @@
 <?php
 namespace SilMock\Google\Service;
 
+use SilMock\Google\Service\Directory\Asps;
 use SilMock\Google\Service\Directory\UsersResource;
 use SilMock\Google\Service\Directory\UsersAliasesResource;
 
-class Directory {
-
+class Directory
+{
     public $users;
     public $users_aliases;
-
+    
     /**
      * Sets the users and users_aliases properties to be instances of
      *    the corresponding mock classes.
@@ -18,8 +19,8 @@ class Directory {
      */
     public function __construct($client, $dbFile=null)
     {
+        $this->asps = new Asps($dbFile);
         $this->users = new UsersResource($dbFile);
         $this->users_aliases = new UsersAliasesResource($dbFile);
     }
-
-} 
+}

--- a/SilMock/Google/Service/Directory.php
+++ b/SilMock/Google/Service/Directory.php
@@ -2,6 +2,7 @@
 namespace SilMock\Google\Service;
 
 use SilMock\Google\Service\Directory\Asps;
+use SilMock\Google\Service\Directory\Tokens;
 use SilMock\Google\Service\Directory\UsersResource;
 use SilMock\Google\Service\Directory\UsersAliasesResource;
 
@@ -20,6 +21,7 @@ class Directory
     public function __construct($client, $dbFile=null)
     {
         $this->asps = new Asps($dbFile);
+        $this->tokens = new Tokens($dbFile);
         $this->users = new UsersResource($dbFile);
         $this->users_aliases = new UsersAliasesResource($dbFile);
     }

--- a/SilMock/Google/Service/Directory/Asps.php
+++ b/SilMock/Google/Service/Directory/Asps.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilMock\Google\Service\Directory;
+
+use Google_Service_Directory_Asps;
+
+class Asps
+{
+    /** @var string - The path (with file name) to the SQLite database. */
+    private $dbFile;
+    
+    /** @var string - The 'type' field to use in the database. */
+    private $dataType = 'directory';
+    
+    /** @var string - The 'class' field to use in the database */
+    private $dataClass = 'asps';
+    
+    public function __construct($dbFile = null)
+    {
+        $this->dbFile = $dbFile;
+    }
+    
+    public function listAsps($userKey, $optParams = array())
+    {
+        return new Google_Service_Directory_Asps(array(
+            'items' => array(),
+        ));
+    }
+}

--- a/SilMock/Google/Service/Directory/Tokens.php
+++ b/SilMock/Google/Service/Directory/Tokens.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilMock\Google\Service\Directory;
+
+use Google_Service_Directory_Tokens;
+
+class Tokens
+{
+    /** @var string - The path (with file name) to the SQLite database. */
+    private $dbFile;
+    
+    /** @var string - The 'type' field to use in the database. */
+    private $dataType = 'directory';
+    
+    /** @var string - The 'class' field to use in the database */
+    private $dataClass = 'tokens';
+    
+    public function __construct($dbFile = null)
+    {
+        $this->dbFile = $dbFile;
+    }
+    
+    public function listTokens($userKey, $optParams = array())
+    {
+        return new Google_Service_Directory_Tokens(array(
+            'items' => array(),
+        ));
+    }
+}

--- a/SilMock/Google/Service/Gmail.php
+++ b/SilMock/Google/Service/Gmail.php
@@ -3,6 +3,7 @@ namespace SilMock\Google\Service;
 
 use SilMock\Google\Service\Gmail\Resource\UsersSettings;
 use SilMock\Google\Service\Gmail\Resource\UsersSettingsDelegates;
+use SilMock\Google\Service\Gmail\Resource\UsersSettingsForwardingAddresses;
 
 class Gmail
 {
@@ -12,5 +13,6 @@ class Gmail
     {
         $this->users_settings = new UsersSettings();
         $this->users_settings_delegates = new UsersSettingsDelegates();
+        $this->users_settings_forwardingAddresses = new UsersSettingsForwardingAddresses();
     }
 }

--- a/SilMock/Google/Service/Gmail.php
+++ b/SilMock/Google/Service/Gmail.php
@@ -1,6 +1,7 @@
 <?php
 namespace SilMock\Google\Service;
 
+use SilMock\Google\Service\Gmail\Resource\UsersSettings;
 use SilMock\Google\Service\Gmail\Resource\UsersSettingsDelegates;
 
 class Gmail
@@ -9,6 +10,7 @@ class Gmail
     
     public function __construct($client, $dbFile = null)
     {
+        $this->users_settings = new UsersSettings();
         $this->users_settings_delegates = new UsersSettingsDelegates();
     }
 }

--- a/SilMock/Google/Service/Gmail/Resource/UsersSettings.php
+++ b/SilMock/Google/Service/Gmail/Resource/UsersSettings.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilMock\Google\Service\Gmail\Resource;
+
+use Google_Service_Gmail_PopSettings;
+use SilMock\DataStore\Sqlite\SqliteUtils;
+use SilMock\Google\Service\Directory\ObjectUtils;
+use Webmozart\Assert\Assert;
+
+class UsersSettings
+{
+    /** @var string - The path (with file name) to the SQLite database. */
+    private $dbFile;
+    
+    /** @var string - The 'type' field to use in the database. */
+    private $dataType = 'gmail';
+    
+    /** @var string - The 'class' field to use in the database */
+    private $dataClass = 'users_settings';
+    
+    public function __construct($dbFile = null)
+    {
+        $this->dbFile = $dbFile;
+    }
+    
+    public function updatePop($userId, Google_Service_Gmail_PopSettings $postBody, $optParams = array())
+    {
+        // No action necessary, since we do not yet mock any way to check the pop settings.
+    }
+}

--- a/SilMock/Google/Service/Gmail/Resource/UsersSettings.php
+++ b/SilMock/Google/Service/Gmail/Resource/UsersSettings.php
@@ -2,6 +2,7 @@
 
 namespace SilMock\Google\Service\Gmail\Resource;
 
+use Google_Service_Gmail_ImapSettings;
 use Google_Service_Gmail_PopSettings;
 use SilMock\DataStore\Sqlite\SqliteUtils;
 use SilMock\Google\Service\Directory\ObjectUtils;
@@ -26,5 +27,10 @@ class UsersSettings
     public function updatePop($userId, Google_Service_Gmail_PopSettings $postBody, $optParams = array())
     {
         // No action necessary, since we do not yet mock any way to check the pop settings.
+    }
+    
+    public function updateImap($userId, Google_Service_Gmail_ImapSettings $postBody, $optParams = array())
+    {
+        // No action necessary, since we do not yet mock any way to check the IMAP settings.
     }
 }

--- a/SilMock/Google/Service/Gmail/Resource/UsersSettingsDelegates.php
+++ b/SilMock/Google/Service/Gmail/Resource/UsersSettingsDelegates.php
@@ -2,6 +2,7 @@
 
 namespace SilMock\Google\Service\Gmail\Resource;
 
+use Google_Service_Gmail_ListDelegatesResponse;
 use SilMock\DataStore\Sqlite\SqliteUtils;
 use SilMock\Google\Service\Directory\ObjectUtils;
 use Webmozart\Assert\Assert;
@@ -169,5 +170,12 @@ class UsersSettingsDelegates
     {
         $sqliteUtils = $this->getSqliteUtils();
         $sqliteUtils->deleteRecordById($recordId);
+    }
+    
+    public function listUsersSettingsDelegates($userId, $optParams = array())
+    {
+        return new Google_Service_Gmail_ListDelegatesResponse(array(
+            'delegates' => array(),
+        ));
     }
 }

--- a/SilMock/Google/Service/Gmail/Resource/UsersSettingsForwardingAddresses.php
+++ b/SilMock/Google/Service/Gmail/Resource/UsersSettingsForwardingAddresses.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilMock\Google\Service\Gmail\Resource;
+
+use Google_Service_Gmail_ListForwardingAddressesResponse;
+use Webmozart\Assert\Assert;
+
+class UsersSettingsForwardingAddresses
+{
+    /** @var string - The path (with file name) to the SQLite database. */
+    private $dbFile;
+    
+    /** @var string - The 'type' field to use in the database. */
+    private $dataType = 'gmail';
+    
+    /** @var string - The 'class' field to use in the database */
+    private $dataClass = 'users_settings_forwardingAddresses';
+    
+    public function __construct($dbFile = null)
+    {
+        $this->dbFile = $dbFile;
+    }
+    
+    public function listUsersSettingsForwardingAddresses($userId, $optParams = array())
+    {
+        return new Google_Service_Gmail_ListForwardingAddressesResponse(array(
+            'forwardingAddresses' => array(),
+        ));
+    }
+}

--- a/SilMock/tests/Google/Service/DirectoryTest.php
+++ b/SilMock/tests/Google/Service/DirectoryTest.php
@@ -38,13 +38,22 @@ class DirectoryTest extends PHPUnit_Framework_TestCase
 
     public function testDirectory()
     {
-        $dir = new Directory('whatever', $this->dataFile);
-        $results = json_encode($dir);
-        $expected = '{"users":{},"users_aliases":{}}';
-        $msg = " *** Directory was not initialized properly";
-        $this->assertEquals($expected, $results, $msg);
-
-        $ma = array('a'=>1, 'b'=>2, 'c'=>array());
+        $expectedKeys = array(
+            'asps',
+            'tokens',
+            'users',
+            'users_aliases',
+        );
+        $errorMessage = " *** Directory was not initialized properly";
+        
+        $directory = new Directory('whatever', $this->dataFile);
+        
+        $directoryAsJson = json_encode($directory);
+        $directoryInfo = json_decode($directoryAsJson, true);
+        foreach ($expectedKeys as $expectedKey) {
+            $this->assertArrayHasKey($expectedKey, $directoryInfo, $errorMessage);
+            $this->assertEmpty($directoryInfo[$expectedKey], $errorMessage);
+        }
     }
 
     public function testUsersInsert()

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require": {
         "php": ">=5.3.3",
         "ext-json": "*",
-        "google/apiclient": "^1.1"
+        "google/apiclient": "^1.1",
+        "google/apiclient-services": "^0.83"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64c1a8b536407133f123a8525ec235ef",
+    "content-hash": "373f6dac275bd6cd0d96d5ac07790dbb",
     "packages": [
         {
             "name": "google/apiclient",
@@ -48,6 +48,43 @@
                 "google"
             ],
             "time": "2016-06-06T21:22:48+00:00"
+        },
+        {
+            "name": "google/apiclient-services",
+            "version": "v0.83",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-api-php-client-services.git",
+                "reference": "f443f4107d9ba001dad60d18cf1ec0cf0e7234f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/f443f4107d9ba001dad60d18cf1ec0cf0e7234f9",
+                "reference": "f443f4107d9ba001dad60d18cf1ec0cf0e7234f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Google_Service_": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Client library for Google APIs",
+            "homepage": "http://developers.google.com/api-client-library/php",
+            "keywords": [
+                "google"
+            ],
+            "time": "2019-01-30T22:06:40+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
**Added:**
- Gmail API endpoint mocks:
  * `user_settings->updatePop()`
  * `user_settings->updateImap()`
  * `user_settings_delegates->listUsersSettingsDelegates()`
  * `users_settings_forwardingAddresses->listUsersSettingsForwardingAddresses()`
- Admin SDK Directory endpoint mocks:
  * `asps->listAsps()`
  * `tokens->listTokens()`

**Fixed:**
- Fixed test of new Directory object to allow for additional properties.