### PR TITLE
Fix listUsersSettingsDelegates() method

### DIFF
--- a/SilMock/Google/Service/Gmail/Resource/UsersSettingsDelegates.php
+++ b/SilMock/Google/Service/Gmail/Resource/UsersSettingsDelegates.php
@@ -174,8 +174,8 @@ class UsersSettingsDelegates
     
     public function listUsersSettingsDelegates($userId, $optParams = array())
     {
-        return new Google_Service_Gmail_ListDelegatesResponse(array(
-            'delegates' => array(),
-        ));
+        $response = new Google_Service_Gmail_ListDelegatesResponse();
+        $response->setDelegates($this->listDelegatesFor($userId));
+        return $response;
     }
 }

--- a/SilMock/tests/Google/Service/Gmail/Resource/UsersSettingsDelegatesTest.php
+++ b/SilMock/tests/Google/Service/Gmail/Resource/UsersSettingsDelegatesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use PHPUnit\Framework\Assert;
+use SilMock\Google\Service\Gmail\Resource\UsersSettingsDelegates;
+use SilMock\Google\Service\GoogleFixtures;
+
+class UsersSettingsDelegatesTest extends PHPUnit\Framework\TestCase
+{
+    public $dataFile = DATAFILE4;
+    
+    protected function setUp(): void
+    {
+        $this->emptyFixturesDataFile();
+    }
+    
+    private function emptyFixturesDataFile()
+    {
+        $fixturesClass = new GoogleFixtures($this->dataFile);
+        $fixturesClass->removeAllFixtures();
+    }
+    
+    protected function tearDown(): void
+    {
+        $this->emptyFixturesDataFile();
+    }
+    
+    public function testListUsersSettingsDelegates()
+    {
+        // Arrange:
+        $accountEmail = 'john_smith@example.org';
+        $delegateEmail = 'mike_manager@example.org';
+        
+        // Act
+        $before = $this->getDelegatesForAccount($accountEmail);
+        $this->delegateAccessToAccountBy($accountEmail, $delegateEmail);
+        $after = $this->getDelegatesForAccount($accountEmail);
+        
+        // Assert:
+        $delegatesBefore = $before->getDelegates();
+        Assert::assertEmpty($delegatesBefore);
+        
+        $delegatesAfter = $after->getDelegates();
+        Assert::assertNotEmpty($delegatesAfter);
+        
+        $foundExpectedDelegate = false;
+        foreach ($delegatesAfter as $delegate) {
+            if ($delegate->delegateEmail === $delegateEmail) {
+                $foundExpectedDelegate = true;
+                break;
+            }
+        }
+        Assert::assertTrue($foundExpectedDelegate, sprintf(
+            'Did not find %s in %s',
+            $delegateEmail,
+            json_encode($delegatesAfter)
+        ));
+    }
+    
+    private function delegateAccessToAccountBy(
+        string $accountEmail,
+        string $delegateEmail
+    ) {
+        $gmailDelegate = new Google_Service_Gmail_Delegate();
+        $gmailDelegate->setDelegateEmail($delegateEmail);
+        $userSettingsDelegates = new UsersSettingsDelegates($this->dataFile);
+        $userSettingsDelegates->create(
+            $accountEmail,
+            $gmailDelegate
+        );
+    }
+    
+    private function getDelegatesForAccount(string $emailAddress)
+    {
+        $userSettingsDelegates = new UsersSettingsDelegates($this->dataFile);
+        return $userSettingsDelegates->listUsersSettingsDelegates($emailAddress);
+    }
+} 

--- a/SilMock/tests/bootstrap.php
+++ b/SilMock/tests/bootstrap.php
@@ -6,6 +6,7 @@
 define('DATAFILE1', __DIR__.'/../DataStore/Sqlite/Test1_Google_Service_Data.db');
 define('DATAFILE2', __DIR__.'/../DataStore/Sqlite/Test2_Google_Service_Data.db');
 define('DATAFILE3', __DIR__.'/../DataStore/Sqlite/Test3_Google_Service_Data.db');
+define('DATAFILE4', __DIR__.'/../DataStore/Sqlite/Test4_Google_Service_Data.db');
 
 if(!file_exists(DATAFILE1)){
     touch(DATAFILE1);
@@ -17,4 +18,8 @@ if(!file_exists(DATAFILE2)){
 
 if(!file_exists(DATAFILE3)){
     touch(DATAFILE3);
+}
+
+if(!file_exists(DATAFILE4)){
+    touch(DATAFILE4);
 }


### PR DESCRIPTION
Our mock previously always returned an empty array of delegates. This fixes it to return any actual delegates the mock was given.