### PR TITLE
Release 0.9.0

### DIFF
--- a/SilMock/Google/Service/Directory/ObjectUtils.php
+++ b/SilMock/Google/Service/Directory/ObjectUtils.php
@@ -1,27 +1,25 @@
 <?php
-namespace SilMock\Google\Service\Directory;
 
+namespace SilMock\Google\Service\Directory;
 
 class ObjectUtils
 {
-
     /**
      * Assigns given values to the matching properties of a Google Mock object
      *
      * @param object $newObject -- a Google mock object
      * @param object|array $properties -- object|associative array
-     * @returns null
-     **/
-    public static function initialize($newObject, $properties)
+     * @return void
+     */
+    public static function initialize(object $newObject, $properties)
     {
         $propArray = $properties;
         if (is_object($properties)) {
             $propArray = get_object_vars($properties);
         }
 
-        foreach ($propArray as $key=>$value) {
+        foreach ($propArray as $key => $value) {
             $newObject->$key = $value;
         }
     }
-
-} 
+}

--- a/SilMock/Google/Service/Directory/UsersAliasesResource.php
+++ b/SilMock/Google/Service/Directory/UsersAliasesResource.php
@@ -1,16 +1,18 @@
 <?php
+
 namespace SilMock\Google\Service\Directory;
 
 use SilMock\DataStore\Sqlite\SqliteUtils;
 
-class UsersAliasesResource {
+class UsersAliasesResource
+{
 
     private $_dbFile;  // string for the path (with file name) for the Sqlite database
     private $_dataType = 'directory';  // string to put in the 'type' field in the database
     private $_dataClass = 'users_alias'; // string to put in the 'class' field in the database
 
 
-    public function __construct($dbFile=null)
+    public function __construct($dbFile = null)
     {
         $this->_dbFile = $dbFile;
     }
@@ -27,9 +29,8 @@ class UsersAliasesResource {
     {
         // If the $userKey is not an email address, it must be an id
         $key = 'primaryEmail';
-        if ( ! filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
+        if (! filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
             $key = 'id';
-            $userKey = intval($userKey);
         }
 
         // ensure that user exists in db
@@ -42,10 +43,14 @@ class UsersAliasesResource {
 
         // Get all the aliases for that user
         $sqliteUtils = new SqliteUtils($this->_dbFile);
-        $aliases =  $sqliteUtils->getAllRecordsByDataKey($this->_dataType,
-            $this->_dataClass, $key, $userKey);
+        $aliases =  $sqliteUtils->getAllRecordsByDataKey(
+            $this->_dataType,
+            $this->_dataClass,
+            $key,
+            $userKey
+        );
 
-        if ( ! $aliases) {
+        if (! $aliases) {
             return null;
         }
 
@@ -74,9 +79,8 @@ class UsersAliasesResource {
     {
         // If the $userKey is not an email address, it must be an id
         $key = 'primaryEmail';
-        if ( ! filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
+        if (! filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
             $key = 'id';
-            $userKey = intval($userKey);
         }
 
         // ensure that user exists in db
@@ -111,7 +115,7 @@ class UsersAliasesResource {
         );
         $allAliases = $sqliteUtils->getData($this->_dataType, $this->_dataClass);
 
-        if ( ! $allAliases) {
+        if (! $allAliases) {
             return null;
         }
 
@@ -134,9 +138,8 @@ class UsersAliasesResource {
     {
         // If the $userKey is not an email address, it must be an id
         $key = 'primaryEmail';
-        if ( ! filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
+        if (! filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
             $key = 'id';
-            $userKey = intval($userKey);
         }
         // ensure that user exists in db
         $dir = new \SilMock\Google\Service\Directory('anything', $this->_dbFile);
@@ -160,12 +163,17 @@ class UsersAliasesResource {
      * @param string $userKey - The Email or immutable Id of the user
      * @return null|Google_Service_Directory_Aliases
      */
-    public function fetchAliasesByUser($keyType, $userKey) {
+    public function fetchAliasesByUser($keyType, $userKey)
+    {
         $sqliteUtils = new SqliteUtils($this->_dbFile);
-        $aliases =  $sqliteUtils->getAllRecordsByDataKey($this->_dataType,
-            $this->_dataClass, $keyType, $userKey);
+        $aliases =  $sqliteUtils->getAllRecordsByDataKey(
+            $this->_dataType,
+            $this->_dataClass,
+            $keyType,
+            $userKey
+        );
 
-        if ( ! $aliases) {
+        if (! $aliases) {
             return null;
         }
 

--- a/SilMock/Google/Service/Directory/UsersResource.php
+++ b/SilMock/Google/Service/Directory/UsersResource.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace SilMock\Google\Service\Directory;
 
 use SilMock\DataStore\Sqlite\SqliteUtils;
-
 use Google_Service_Directory_User;
 
 class UsersResource
@@ -87,7 +87,6 @@ class UsersResource
         $key = 'primaryEmail';
         if (! filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
             $key = 'id';
-            $userKey = intval($userKey);
         }
         
         $usersAliases = new UsersAliasesResource($this->_dbFile);
@@ -157,7 +156,7 @@ class UsersResource
     public function insert($postBody)
     {
         $defaults = array(
-            'id' => intval(str_replace(array(' ', '.'), '', microtime())),
+            'id' => str_replace(array(' ', '.'), '', microtime()),
             'suspended' => false,
             'changePasswordAtNextLogin' => false,
             'isAdmin' => false,
@@ -219,11 +218,10 @@ class UsersResource
      */
     public function update($userKey, $postBody)
     {
-
         $userEntry = $this->getDbUser($userKey);
         if ($userEntry === null) {
             throw new \Exception(
-                "Account doesn't exist: " . $userKey,
+                "Account doesn't exist: " . json_encode($userKey, true),
                 201407101130
             );
         }
@@ -232,7 +230,6 @@ class UsersResource
          * only keep the non-null properties of the $postBody user,
          * except for suspensionReason.
          */
-
         $dbUserProps = json_decode($userEntry['data'], true);
         $newUserProps = get_object_vars($postBody);
 
@@ -257,7 +254,6 @@ class UsersResource
 
         // Save the user's aliases
         if (isset($postBody->aliases) && $postBody->aliases) {
-
             foreach ($postBody->aliases as $alias) {
                 $newAlias = new \Google_Service_Directory_Alias();
                 $newAlias->alias = $alias;
@@ -275,15 +271,14 @@ class UsersResource
      * Retrieves a user record from the database (users.delete)
      *
      * @param string $userKey - The Email or immutable Id of the user
-     * @return null|nested array for the matching database entry
+     * @return null|array -- nested array for the matching database entry
      */
-    private function getDbUser($userKey)
+    private function getDbUser(string $userKey)
     {
 
         $key = 'primaryEmail';
         if (! filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
             $key = 'id';
-            $userKey = intval($userKey);
         }
 
         $sqliteUtils = new SqliteUtils($this->_dbFile);
@@ -345,7 +340,7 @@ class UsersResource
                 $allResultsUsers[] = $newEntry;
                 $results->setUsers($allResultsUsers);
             }
-            if (count($results->getUsers())>= $parameters['maxResults']) {
+            if (count($results->getUsers()) >= $parameters['maxResults']) {
                 break;
             }
         }
@@ -354,7 +349,7 @@ class UsersResource
 
     private function doesUserMatch($entry, $query = '')
     {
-        if ($query==='') {
+        if ($query === '') {
             return true;
         }
         $query = str_replace('*', '', $query);

--- a/SilMock/Google/Service/Directory/VerificationCodesResource.php
+++ b/SilMock/Google/Service/Directory/VerificationCodesResource.php
@@ -79,12 +79,14 @@ class VerificationCodesResource
             $key,
             $userKey
         );
-        $verificationCodeData = $data[0]['data'];
-        $decodedVerificationCodeData = json_decode($verificationCodeData, true);
-        unset($decodedVerificationCodeData['primaryEmail']);
-
         $verificationCodes = new \Google_Service_Directory_VerificationCodes();
-        ObjectUtils::initialize($verificationCodes, $decodedVerificationCodeData['data']);
+        if (! empty($data)) {
+            $verificationCodeData = $data[0]['data'];
+            $decodedVerificationCodeData = json_decode($verificationCodeData, true);
+            unset($decodedVerificationCodeData['primaryEmail']);
+
+            ObjectUtils::initialize($verificationCodes, $decodedVerificationCodeData['data']);
+        }
         return $verificationCodes;
     }
 

--- a/SilMock/Google/Service/Directory/VerificationCodesResource.php
+++ b/SilMock/Google/Service/Directory/VerificationCodesResource.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilMock\Google\Service\Directory;
 
 use SilMock\DataStore\Sqlite\SqliteUtils;
@@ -29,7 +30,6 @@ class VerificationCodesResource
         $key = 'primaryEmail';
         if (!filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
             $key = 'id';
-            $userKey = intval($userKey);
         }
 
         // ensure that user exists in db
@@ -69,7 +69,6 @@ class VerificationCodesResource
         $key = 'primaryEmail';
         if (!filter_var($userKey, FILTER_VALIDATE_EMAIL)) {
             $key = 'id';
-            $userKey = intval($userKey);
         }
 
         $sqliteUtils = new SqliteUtils($this->_dbFile);

--- a/SilMock/tests/Google/Service/DirectoryTest.php
+++ b/SilMock/tests/Google/Service/DirectoryTest.php
@@ -13,9 +13,11 @@ use SilMock\Google\Service\GoogleFixtures;
 class DirectoryTest extends TestCase
 {
     use SampleUser;
+
     public $dataFile = DATAFILE2;
 
-    public function getProperties($object, $propKeys = null) {
+    public function getProperties($object, $propKeys = null)
+    {
         if ($propKeys === null) {
             $propKeys = array(
                 "changePasswordAtNextLogin",
@@ -153,10 +155,11 @@ class DirectoryTest extends TestCase
         $this->assertEquals($expected, $results, $msg);
     }
 
-    public function getFixtures() {
+    public function getFixtures()
+    {
         $user4Data = '{"changePasswordAtNextLogin":false,' .
             '"hashFunction":"SHA-1",' .
-            '"id":999991,"password":"testP4ss",' .
+            '"id":"999991","password":"testP4ss",' .
             '"primaryEmail":"user_test4@sil.org",' .
             '"isEnforcedIn2Sv":false,' .
             '"isEnrolledIn2Sv":true,' .
@@ -168,11 +171,11 @@ class DirectoryTest extends TestCase
 
         $alias6 = new Google_Service_Directory_Alias();
         $alias6->setAlias("users_alias6@sil.org");
-        $alias6->setId(1);
+        $alias6->setId("1");
 
         $fixtures = array(
             array('directory', 'user', '{"primaryEmail":"user_test1@sil.org",' .
-                                       '"id":999990}'),
+                                       '"id":"999990"}'),
             array('directory', 'users_alias', json_encode($alias2)),
             array('app_engine', 'webapp', 'webapp3 test data'),
             array('directory', 'user', $user4Data),
@@ -183,7 +186,7 @@ class DirectoryTest extends TestCase
         return $fixtures;
     }
 
-    public function getAliasFixture($alias, $email, $id)
+    public function getAliasFixture($alias, $email, ?string $id)
     {
         $newAlias = new Google_Service_Directory_Alias();
         $newAlias->setAlias($alias);
@@ -191,7 +194,7 @@ class DirectoryTest extends TestCase
             $newAlias->setPrimaryEmail($email);
         }
 
-        if ($id) {
+        if (! empty($id)) {
             $newAlias->setId($id);
         }
 
@@ -214,7 +217,7 @@ class DirectoryTest extends TestCase
             "suspended" => false,
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
-            "aliases" =>null,
+            "aliases" => null,
         );
 
         $fixtures = $this->getFixtures();
@@ -245,7 +248,7 @@ class DirectoryTest extends TestCase
             "suspended" => false,
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
-            "aliases" =>null,
+            "aliases" => null,
         );
 
         $fixtures = $this->getFixtures();
@@ -274,7 +277,7 @@ class DirectoryTest extends TestCase
         $userData = array(
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
-            "id" => intval($userId),
+            "id" => $userId,
             "password" => "testP4ss",
             "primaryEmail" => $email,
             "suspended" => false,
@@ -375,7 +378,7 @@ class DirectoryTest extends TestCase
         $fixturesClass = new GoogleFixtures($this->dataFile);
         $fixturesClass->removeAllFixtures();
 
-        $userId = 999991;
+        $userId = '999991';
 
         $userData = array(
             "changePasswordAtNextLogin" => false,
@@ -447,8 +450,11 @@ class DirectoryTest extends TestCase
 
         $primaryEmail = "user_test4@sil.org";
 
-        $aliasFixture = $this->getAliasFixture("users_alias4B@sil.org",
-            $primaryEmail, null);
+        $aliasFixture = $this->getAliasFixture(
+            "users_alias4B@sil.org",
+            $primaryEmail,
+            null
+        );
         $newFixtures = array(
             array('directory', 'users_alias', json_encode($aliasFixture)),
         );
@@ -533,7 +539,7 @@ class DirectoryTest extends TestCase
         $expected = array(
             array('id' => 1, 'type' => 'directory', 'class' => 'user',
                   'data' => '{"primaryEmail":"user_test1@sil.org",' .
-                              '"id":999990}'),
+                              '"id":"999990"}'),
             array('id' => 2, 'type' => 'directory', 'class' => 'users_alias',
                   'data' => '{"alias":"users_alias2@sil.org","etag":null,' .
                             '"id":null,"kind":null,' .
@@ -544,7 +550,7 @@ class DirectoryTest extends TestCase
                   'data' => 'user5 test data'),
             array('id' => 6, 'type' => 'directory', 'class' => 'users_alias',
                   'data' => '{"alias":"users_alias6@sil.org","etag":null,' .
-                  '"id":1,"kind":null,"primaryEmail":null}'),
+                  '"id":"1","kind":null,"primaryEmail":null}'),
         );
 
         $msg = " *** Bad database data returned";
@@ -570,7 +576,7 @@ class DirectoryTest extends TestCase
         $expected = array(
             array('id' => 1, 'type' => 'directory', 'class' => 'user',
                 'data' => '{"primaryEmail":"user_test1@sil.org",' .
-                    '"id":999990}'),
+                    '"id":"999990"}'),
             array('id' => 2, 'type' => 'directory', 'class' => 'users_alias',
                 'data' => '{"alias":"users_alias2@sil.org","etag":null,' .
                     '"id":null,"kind":null,' .
@@ -581,7 +587,7 @@ class DirectoryTest extends TestCase
                 'data' => 'user5 test data'),
             array('id' => 6, 'type' => 'directory', 'class' => 'users_alias',
                 'data' => '{"alias":"users_alias6@sil.org","etag":null,' .
-                    '"id":1,"kind":null,"primaryEmail":null}'),
+                    '"id":"1","kind":null,"primaryEmail":null}'),
         );
 
         $msg = " *** Bad database data returned";
@@ -648,8 +654,11 @@ class DirectoryTest extends TestCase
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
 
-        $aliasFixture = $this->getAliasFixture("users_alias7@sil.org",
-                                                  "user_test1@sil.org", 1);
+        $aliasFixture = $this->getAliasFixture(
+            "users_alias7@sil.org",
+            "user_test1@sil.org",
+            "1"
+        );
 
         $newFixtures = array(
             array('directory', 'users_alias', json_encode($aliasFixture)),
@@ -667,13 +676,12 @@ class DirectoryTest extends TestCase
         $expected = array(
             '{"alias":"users_alias2@sil.org","etag":null,"id":null,' .
               '"kind":null,"primaryEmail":"user_test1@sil.org"}',
-            '{"alias":"users_alias7@sil.org","etag":null,"id":1,' .
+            '{"alias":"users_alias7@sil.org","etag":null,"id":"1",' .
               '"kind":null,"primaryEmail":"user_test1@sil.org"}'
         );
 
         $msg = " *** Bad returned Aliases";
         $this->assertEquals($expected, $results, $msg);
-
     }
 
     public function testUsersAliasesListUsersAliases_ID()
@@ -685,12 +693,12 @@ class DirectoryTest extends TestCase
         $fixturesClass->addFixtures($fixtures);
         $email = "user_test7@sil.org";
 
-        $aliasB = $this->getAliasFixture("users_alias7b@sil.org", $email, 7);
-        $aliasC = $this->getAliasFixture("users_alias7c@sil.org", null, 7);
+        $aliasB = $this->getAliasFixture("users_alias7b@sil.org", $email, "7");
+        $aliasC = $this->getAliasFixture("users_alias7c@sil.org", null, "7");
 
         $newFixtures = array(
             array('directory', 'user',
-                    '{"id":7,"primaryEmail":"' . $email . '",' .
+                    '{"id":"7","primaryEmail":"' . $email . '",' .
                      '"aliases":[]}'),
             array('directory', 'users_alias', json_encode($aliasB)),
             array('directory', 'users_alias', json_encode($aliasC)),
@@ -706,15 +714,14 @@ class DirectoryTest extends TestCase
         }
 
         $expected = array(
-            '{"alias":"users_alias7b@sil.org","etag":null,"id":7,"kind":null,' .
+            '{"alias":"users_alias7b@sil.org","etag":null,"id":"7","kind":null,' .
                '"primaryEmail":"user_test7@sil.org"}',
-            '{"alias":"users_alias7c@sil.org","etag":null,"id":7,"kind":null,' .
+            '{"alias":"users_alias7c@sil.org","etag":null,"id":"7","kind":null,' .
                '"primaryEmail":null}',
         );
 
         $msg = " *** Bad returned Aliases";
         $this->assertEquals($expected, $results, $msg);
-
     }
 
     public function testUsersAliasesListUsersAliases_Structure()
@@ -726,7 +733,7 @@ class DirectoryTest extends TestCase
         $fixturesClass->addFixtures($fixtures);
         $email = "user_test1@sil.org";
 
-        $alias = $this->getAliasFixture("users_alias7@sil.org", $email, 1);
+        $alias = $this->getAliasFixture("users_alias7@sil.org", $email, "1");
         $newFixtures = array(
             array('directory', 'users_alias', json_encode($alias)),
         );
@@ -744,7 +751,7 @@ class DirectoryTest extends TestCase
 
         $user_aliases = array();
 
-        foreach($aliases['aliases'] as $alias) {
+        foreach ($aliases['aliases'] as $alias) {
             $user_aliases[] = $alias['alias'];
         }
 
@@ -761,8 +768,11 @@ class DirectoryTest extends TestCase
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
-        $alias = $this->getAliasFixture("users_alias7@sil.org",
-                                          "user_test1@sil.org", 1);
+        $alias = $this->getAliasFixture(
+            "users_alias7@sil.org",
+            "user_test1@sil.org",
+            "1"
+        );
         $newFixtures = array(
             array('directory', 'users_alias', json_encode($alias)),
         );
@@ -783,7 +793,7 @@ class DirectoryTest extends TestCase
         $fixturesClass->addFixtures($fixtures);
         $email = "user_test1@sil.org";
 
-        $alias = $this->getAliasFixture("users_alias7@sil.org", $email, 1);
+        $alias = $this->getAliasFixture("users_alias7@sil.org", $email, "1");
 
         $newFixtures = array(
             array('directory', 'users_alias', json_encode($alias)),
@@ -791,8 +801,10 @@ class DirectoryTest extends TestCase
         $fixturesClass->addFixtures($newFixtures);
 
         $newDir = new Directory('anyclient', $this->dataFile);
-        $results = $newDir->users_aliases->delete("user_test1@sil.org",
-                                                  "users_alias2@sil.org");
+        $results = $newDir->users_aliases->delete(
+            "user_test1@sil.org",
+            "users_alias2@sil.org"
+        );
 
         $this->assertTrue($results, " *** Didn't appear to delete the alias.");
 
@@ -804,17 +816,16 @@ class DirectoryTest extends TestCase
                   'type' => 'directory',
                   'class' => 'users_alias',
                   'data' => '{"alias":"users_alias6@sil.org","etag":null,' .
-                            '"id":1,"kind":null,"primaryEmail":null}',
+                            '"id":"1","kind":null,"primaryEmail":null}',
             ),
             array('id' => '7',
                 'type' => 'directory',
                 'class' => 'users_alias',
                 'data' => '{"alias":"users_alias7@sil.org","etag":null,' .
-                          '"id":1,"kind":null,"primaryEmail":"' . $email . '"}'),
+                          '"id":"1","kind":null,"primaryEmail":"' . $email . '"}'),
         );
         $msg = " *** Mismatching users_aliases in db";
         $this->assertEquals($expected, $results, $msg);
-
     }
 
     public function testUserArrayAccess()
@@ -824,7 +835,6 @@ class DirectoryTest extends TestCase
 
         $this->assertFalse($user->suspended, ' *** class access failed');
         $this->assertFalse($user['suspended'], ' *** array access failed');
-
     }
 
     public function testUserClassAccess()
@@ -834,7 +844,6 @@ class DirectoryTest extends TestCase
 
         $this->assertFalse($user->suspended, ' *** class access failed');
         $this->assertFalse($user['suspended'], ' *** array access failed');
-
     }
 
     public function testAliasArrayAccess()
@@ -845,7 +854,6 @@ class DirectoryTest extends TestCase
 
         $this->assertEquals($email, $alias->primaryEmail, ' *** class access failed');
         $this->assertEquals($email, $alias['primaryEmail'], ' *** array access failed');
-
     }
 
     public function testAliasClassAccess()
@@ -856,6 +864,5 @@ class DirectoryTest extends TestCase
 
         $this->assertEquals($email, $alias->primaryEmail, ' *** class access failed');
         $this->assertEquals($email, $alias['primaryEmail'], ' *** array access failed');
-
     }
-} 
+}


### PR DESCRIPTION
Fixed 'id' to be string, as documented in Google Admin SDK User page.