### PR TITLE
Ensure alias created when account renamed

### DIFF
--- a/SilMock/tests/Google/Service/DirectoryTest.php
+++ b/SilMock/tests/Google/Service/DirectoryTest.php
@@ -14,42 +14,44 @@ class DirectoryTest extends TestCase
 {
     use SampleUser;
 
-    public $dataFile = DATAFILE2;
+    public string $dataFile = DATAFILE2;
 
-    public function getProperties($object, $propKeys = null)
+    public function getProperties($object, $propKeys = null): array
     {
-        if ($propKeys === null) {
-            $propKeys = array(
-                "changePasswordAtNextLogin",
-                "hashFunction",
-                "id",
-                "password",
-                "primaryEmail",
-                "suspended",
-                "isEnforcedIn2Sv",
-                "isEnrolledIn2Sv",
-                "aliases",
-            );
+        $outArray = [];
+
+        if ($object !== null) {
+            if ($propKeys === null) {
+                $propKeys = [
+                    "changePasswordAtNextLogin",
+                    "hashFunction",
+                    "id",
+                    "password",
+                    "primaryEmail",
+                    "suspended",
+                    "isEnforcedIn2Sv",
+                    "isEnrolledIn2Sv",
+                    "aliases",
+                ];
+            }
+
+
+            foreach ($propKeys as $key) {
+                $outArray[$key] = $object->$key;
+            }
         }
-
-        $outArray = array();
-
-        foreach ($propKeys as $key) {
-            $outArray[$key] = $object->$key;
-        }
-
         return $outArray;
     }
 
     public function testDirectory()
     {
-        $expectedKeys = array(
+        $expectedKeys = [
             'asps',
             'users',
             'users_aliases',
             'verificationCodes',
             'tokens',
-        );
+        ];
         $errorMessage = " *** Directory was not initialized properly";
         
         $directory = new Directory('whatever', $this->dataFile);
@@ -64,10 +66,10 @@ class DirectoryTest extends TestCase
 
     public function testUsersInsert()
     {
-        $newUser = $this->setupSampleUser($this->dataFile, false);
+        $newUser = $this->setupSampleUser($this->dataFile);
         $results = $this->getProperties($newUser);
 
-        $expected = array(
+        $expected = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => 999991,
@@ -77,7 +79,7 @@ class DirectoryTest extends TestCase
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
             "aliases" => null,
-        );
+        ];
         $msg = " *** Bad returned user";
         $this->assertEquals($expected, $results, $msg);
 
@@ -88,7 +90,7 @@ class DirectoryTest extends TestCase
         $dataObj = json_decode($lastDataEntry['data']);
         $results = $this->getProperties($dataObj);
 
-        $expected = array (
+        $expected = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => 999991,
@@ -98,7 +100,7 @@ class DirectoryTest extends TestCase
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
             "aliases" => null,
-        );
+        ];
 
         $msg = " *** Bad data from sqlite database";
         $this->assertEquals($expected, $results, $msg);
@@ -109,7 +111,7 @@ class DirectoryTest extends TestCase
         $newUser = $this->setupSampleUser($this->dataFile, true);
 
         $results =  $this->getProperties($newUser);
-        $expected = array(
+        $expected = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => 999991,
@@ -118,18 +120,16 @@ class DirectoryTest extends TestCase
             "suspended" => false,
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
-            "aliases" => array(
-                'etag' => null,
-                'kind' => null,
-                'aliases' => array(
-                    array(
+            "aliases" => [
+                0 =>  [
                         'alias' => "user_alias1@sil.org",
                         'etag' => null,
                         'id' => null,
                         'kind' => 'personal',
-                        'primaryEmail' => 'user_test1@sil.org')),
-            ),
-        );
+                        'primaryEmail' => 'user_test1@sil.org'
+                ],
+            ],
+        ];
         $msg = " *** Bad returned user";
         $this->assertEquals($expected, $results, $msg);
 
@@ -139,23 +139,21 @@ class DirectoryTest extends TestCase
         $lastDataEntry = end($sqliteDataValues);
         $lastAliases = json_decode($lastDataEntry['data'], true);
 
-        $results = $lastAliases['aliases']['aliases'];
+        $results = $lastAliases['alias'];
 
-        $expected = array(
-            array(
-                "alias" => "user_alias1@sil.org",
-                "kind" => "personal",
-                "primaryEmail" => "user_test1@sil.org",
-                'etag' => null,
-                'id' => null,
-            ),
-        );
+        $expected = [
+            "alias" => "user_alias1@sil.org",
+            "kind" => "personal",
+            "primaryEmail" => "user_test1@sil.org",
+            'etag' => null,
+            'id' => null,
+        ];
 
         $msg = " *** Bad data from sqlite database";
         $this->assertEquals($expected, $results, $msg);
     }
 
-    public function getFixtures()
+    public function getFixtures(): array
     {
         $user4Data = '{"changePasswordAtNextLogin":false,' .
             '"hashFunction":"SHA-1",' .
@@ -173,20 +171,20 @@ class DirectoryTest extends TestCase
         $alias6->setAlias("users_alias6@sil.org");
         $alias6->setId("1");
 
-        $fixtures = array(
-            array('directory', 'user', '{"primaryEmail":"user_test1@sil.org",' .
-                                       '"id":"999990"}'),
-            array('directory', 'users_alias', json_encode($alias2)),
-            array('app_engine', 'webapp', 'webapp3 test data'),
-            array('directory', 'user', $user4Data),
-            array('directory', 'user', 'user5 test data'),
-            array('directory', 'users_alias', json_encode($alias6)),
-        );
-
-        return $fixtures;
+        return [
+            [
+                'directory', 'user', '{"primaryEmail":"user_test1@sil.org",' .
+                                       '"id":"999990"}'
+            ],
+            ['directory', 'users_alias', json_encode($alias2)],
+            ['app_engine', 'webapp', 'webapp3 test data'],
+            ['directory', 'user', $user4Data],
+            ['directory', 'user', 'user5 test data'],
+            ['directory', 'users_alias', json_encode($alias6)],
+        ];
     }
 
-    public function getAliasFixture($alias, $email, ?string $id)
+    public function getAliasFixture($alias, $email, ?string $id): Google_Service_Directory_Alias
     {
         $newAlias = new Google_Service_Directory_Alias();
         $newAlias->setAlias($alias);
@@ -208,7 +206,7 @@ class DirectoryTest extends TestCase
 
         $primaryEmail = 'user_test4@sil.org';
 
-        $userData = array(
+        $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => 999991,
@@ -218,7 +216,7 @@ class DirectoryTest extends TestCase
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
             "aliases" => null,
-        );
+        ];
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
@@ -239,7 +237,7 @@ class DirectoryTest extends TestCase
 
         $userId = '999991';
 
-        $userData = array(
+        $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => $userId,
@@ -249,7 +247,7 @@ class DirectoryTest extends TestCase
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
             "aliases" => null,
-        );
+        ];
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
@@ -274,7 +272,7 @@ class DirectoryTest extends TestCase
         $userId = '999991';
         $email = "user_test4@sil.org";
 
-        $userData = array(
+        $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => $userId,
@@ -283,17 +281,17 @@ class DirectoryTest extends TestCase
             "suspended" => false,
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
-            "aliases" => array("users_alias1A@sil.org", "users_alias1B@sil.org"),
-        );
+            "aliases" => ["users_alias1A@sil.org", "users_alias1B@sil.org"],
+        ];
 
 
         $aliasA = $this->getAliasFixture("users_alias1A@sil.org", $email, null);
         $aliasB = $this->getAliasFixture("users_alias1B@sil.org", $email, null);
 
-        $newFixtures = array(
-            array('directory', 'users_alias', json_encode($aliasA)),
-            array('directory', 'users_alias', json_encode($aliasB)),
-        );
+        $newFixtures = [
+            ['directory', 'users_alias', json_encode($aliasA)],
+            ['directory', 'users_alias', json_encode($aliasB)],
+        ];
         $fixturesClass->addFixtures($newFixtures);
 
         $newDir = new Directory('anyclient', $this->dataFile);
@@ -317,10 +315,10 @@ class DirectoryTest extends TestCase
         $aliasA = $this->getAliasFixture("users_alias1A@sil.org", $email, null);
         $aliasB = $this->getAliasFixture("users_alias1B@sil.org", $email, null);
         
-        $newFixtures = array(
-            array('directory', 'users_alias', json_encode($aliasA)),
-            array('directory', 'users_alias', json_encode($aliasB)),
-        );
+        $newFixtures = [
+            ['directory', 'users_alias', json_encode($aliasA)],
+            ['directory', 'users_alias', json_encode($aliasB)],
+        ];
         $fixturesClass->addFixtures($newFixtures);
         
         $newDir = new Directory('anyclient', $this->dataFile);
@@ -344,7 +342,7 @@ class DirectoryTest extends TestCase
 
         $primaryEmail = "user_test4@sil.org";
 
-        $userData = array(
+        $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => 999991,
@@ -353,8 +351,8 @@ class DirectoryTest extends TestCase
             "suspended" => false,
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
-            "aliases" => array(),
-        );
+            "aliases" => [],
+        ];
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
@@ -380,7 +378,7 @@ class DirectoryTest extends TestCase
 
         $userId = '999991';
 
-        $userData = array(
+        $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => $userId,
@@ -389,8 +387,8 @@ class DirectoryTest extends TestCase
             "suspended" => false,
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
-            "aliases" => array(),
-        );
+            "aliases" => [],
+        ];
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
@@ -408,6 +406,50 @@ class DirectoryTest extends TestCase
         $this->assertEquals($expected, $results, $msg);
     }
 
+    public function testUsersUpdate_ById_ChangeEmail()
+    {
+        $fixturesClass = new GoogleFixtures($this->dataFile);
+        $fixturesClass->removeAllFixtures();
+
+        $userId = '999991';
+        $oldEmailAddress = 'user_test4@sil.org';
+        $newEmailAddress = 'user_test4a@sil.org';
+
+        $userData = [
+            "changePasswordAtNextLogin" => false,
+            "hashFunction" => "SHA-1",
+            "id" => $userId,
+            "password" => "testP4ss",
+            "primaryEmail" => $newEmailAddress,
+            "suspended" => false,
+            "isEnforcedIn2Sv" => false,
+            "isEnrolledIn2Sv" => true,
+            "aliases" => [],
+        ];
+
+        $fixtures = $this->getFixtures();
+        $fixturesClass->addFixtures($fixtures);
+
+        $newUser = new Google_Service_Directory_User();
+        ObjectUtils::initialize($newUser, $userData);
+
+        $newDir = new Directory('anyclient', $this->dataFile);
+        $newDir->users->update($userId, $newUser);
+        $newUser = $newDir->users->get($userId);
+
+        $results = $this->getProperties($newUser);
+        $expected = $userData;
+        $expected['aliases'][] = $oldEmailAddress;
+        $msg = " *** Bad user data returned";
+        $this->assertEquals($expected, $results, $msg);
+
+        // Attempt to get the user by the alias, after updating the primary email address
+        $newUser = $newDir->users->get($oldEmailAddress);
+        $results = $this->getProperties($newUser);
+        $msg = " *** Bad user data returned";
+        $this->assertEquals($expected, $results, $msg);
+    }
+
     public function testUsersUpdate_WithAlias()
     {
         $fixturesClass = new GoogleFixtures($this->dataFile);
@@ -415,7 +457,7 @@ class DirectoryTest extends TestCase
 
         $primaryEmail = "user_test4@sil.org";
 
-        $userData = array(
+        $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => 999991,
@@ -424,8 +466,8 @@ class DirectoryTest extends TestCase
             "suspended" => false,
             "isEnrolledIn2Sv" => true,
             "isEnforcedIn2Sv" => false,
-            "aliases" => array('user_alias4B@sil.org'),
-        );
+            "aliases" => ['user_alias4B@sil.org'],
+        ];
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
@@ -455,13 +497,13 @@ class DirectoryTest extends TestCase
             $primaryEmail,
             null
         );
-        $newFixtures = array(
-            array('directory', 'users_alias', json_encode($aliasFixture)),
-        );
+        $newFixtures = [
+            ['directory', 'users_alias', json_encode($aliasFixture)],
+        ];
         $fixturesClass->addFixtures($newFixtures);
 
         // Different aliases
-        $userData = array(
+        $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => 999991,
@@ -470,8 +512,8 @@ class DirectoryTest extends TestCase
             "suspended" => false,
             "isEnrolledIn2Sv" => true,
             "isEnforcedIn2Sv" => false,
-            "aliases" => array('user_alias4C@sil.org', 'user_alias4D@sil.org'),
-        );
+            "aliases" => ['user_alias4C@sil.org', 'user_alias4D@sil.org'],
+        ];
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
@@ -498,14 +540,14 @@ class DirectoryTest extends TestCase
 
         $userId = 999999;
 
-        $userData = array(
+        $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-1",
             "id" => $userId,
             "password" => "testP4ss",
             "primaryEmail" => "user_test4@sil.org",
             "suspended" => false,
-        );
+        ];
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
@@ -536,22 +578,32 @@ class DirectoryTest extends TestCase
         $sqliteClass = new SqliteUtils($this->dataFile);
         $results = $sqliteClass->getData('', '');
 
-        $expected = array(
-            array('id' => 1, 'type' => 'directory', 'class' => 'user',
-                  'data' => '{"primaryEmail":"user_test1@sil.org",' .
-                              '"id":"999990"}'),
-            array('id' => 2, 'type' => 'directory', 'class' => 'users_alias',
-                  'data' => '{"alias":"users_alias2@sil.org","etag":null,' .
-                            '"id":null,"kind":null,' .
-                            '"primaryEmail":"user_test1@sil.org"}'),
-            array('id' => 3, 'type' => 'app_engine', 'class' => 'webapp',
-                  'data' => 'webapp3 test data'),
-            array('id' => 5, 'type' => 'directory', 'class' => 'user',
-                  'data' => 'user5 test data'),
-            array('id' => 6, 'type' => 'directory', 'class' => 'users_alias',
-                  'data' => '{"alias":"users_alias6@sil.org","etag":null,' .
-                  '"id":"1","kind":null,"primaryEmail":null}'),
-        );
+        $expected = [
+            [
+                'id' => 1, 'type' => 'directory', 'class' => 'user',
+                'data' => '{"primaryEmail":"user_test1@sil.org",' .
+                           '"id":"999990"}'
+            ],
+            [
+                'id' => 2, 'type' => 'directory', 'class' => 'users_alias',
+                'data' => '{"alias":"users_alias2@sil.org","etag":null,' .
+                           '"id":null,"kind":null,' .
+                           '"primaryEmail":"user_test1@sil.org"}'
+            ],
+            [
+                'id' => 3, 'type' => 'app_engine', 'class' => 'webapp',
+                'data' => 'webapp3 test data'
+            ],
+            [
+                'id' => 5, 'type' => 'directory', 'class' => 'user',
+                'data' => 'user5 test data'
+            ],
+            [
+                'id' => 6, 'type' => 'directory', 'class' => 'users_alias',
+                'data' => '{"alias":"users_alias6@sil.org","etag":null,' .
+                           '"id":"1","kind":null,"primaryEmail":null}'
+            ],
+        ];
 
         $msg = " *** Bad database data returned";
         $this->assertEquals($expected, $results, $msg);
@@ -573,22 +625,32 @@ class DirectoryTest extends TestCase
         $sqliteClass = new SqliteUtils($this->dataFile);
         $results = $sqliteClass->getData('', '');
 
-        $expected = array(
-            array('id' => 1, 'type' => 'directory', 'class' => 'user',
+        $expected = [
+            [
+                'id' => 1, 'type' => 'directory', 'class' => 'user',
                 'data' => '{"primaryEmail":"user_test1@sil.org",' .
-                    '"id":"999990"}'),
-            array('id' => 2, 'type' => 'directory', 'class' => 'users_alias',
+                           '"id":"999990"}'
+            ],
+            [
+                'id' => 2, 'type' => 'directory', 'class' => 'users_alias',
                 'data' => '{"alias":"users_alias2@sil.org","etag":null,' .
-                    '"id":null,"kind":null,' .
-                    '"primaryEmail":"user_test1@sil.org"}'),
-            array('id' => 3, 'type' => 'app_engine', 'class' => 'webapp',
-                'data' => 'webapp3 test data'),
-            array('id' => 5, 'type' => 'directory', 'class' => 'user',
-                'data' => 'user5 test data'),
-            array('id' => 6, 'type' => 'directory', 'class' => 'users_alias',
+                           '"id":null,"kind":null,' .
+                           '"primaryEmail":"user_test1@sil.org"}'
+            ],
+            [
+                'id' => 3, 'type' => 'app_engine', 'class' => 'webapp',
+                'data' => 'webapp3 test data'
+            ],
+            [
+                'id' => 5, 'type' => 'directory', 'class' => 'user',
+                'data' => 'user5 test data'
+            ],
+            [
+                'id' => 6, 'type' => 'directory', 'class' => 'users_alias',
                 'data' => '{"alias":"users_alias6@sil.org","etag":null,' .
-                    '"id":"1","kind":null,"primaryEmail":null}'),
-        );
+                           '"id":"1","kind":null,"primaryEmail":null}'
+            ],
+        ];
 
         $msg = " *** Bad database data returned";
         $this->assertEquals($expected, $results, $msg);
@@ -643,7 +705,7 @@ class DirectoryTest extends TestCase
         $newDir = new Directory('anyclient', $this->dataFile);
         
         $this->expectExceptionCode(201407110830);
-        $newAlias = $newDir->users_aliases->insert("no_user@sil.org", $newAlias);
+        $newDir->users_aliases->insert("no_user@sil.org", $newAlias);
     }
 
     public function testUsersAliasesListUsersAliases_Email()
@@ -660,25 +722,25 @@ class DirectoryTest extends TestCase
             "1"
         );
 
-        $newFixtures = array(
-            array('directory', 'users_alias', json_encode($aliasFixture)),
-        );
+        $newFixtures = [
+            ['directory', 'users_alias', json_encode($aliasFixture)],
+        ];
         $fixturesClass->addFixtures($newFixtures);
 
         $newDir = new Directory('anyclient', $this->dataFile);
         $aliases = $newDir->users_aliases->listUsersAliases("user_test1@sil.org");
 
-        $results = array();
+        $results = [];
         foreach ($aliases['aliases'] as $nextAlias) {
             $results[] = json_encode($nextAlias);
         }
 
-        $expected = array(
+        $expected = [
             '{"alias":"users_alias2@sil.org","etag":null,"id":null,' .
               '"kind":null,"primaryEmail":"user_test1@sil.org"}',
             '{"alias":"users_alias7@sil.org","etag":null,"id":"1",' .
               '"kind":null,"primaryEmail":"user_test1@sil.org"}'
-        );
+        ];
 
         $msg = " *** Bad returned Aliases";
         $this->assertEquals($expected, $results, $msg);
@@ -696,29 +758,31 @@ class DirectoryTest extends TestCase
         $aliasB = $this->getAliasFixture("users_alias7b@sil.org", $email, "7");
         $aliasC = $this->getAliasFixture("users_alias7c@sil.org", null, "7");
 
-        $newFixtures = array(
-            array('directory', 'user',
-                    '{"id":"7","primaryEmail":"' . $email . '",' .
-                     '"aliases":[]}'),
-            array('directory', 'users_alias', json_encode($aliasB)),
-            array('directory', 'users_alias', json_encode($aliasC)),
-        );
+        $newFixtures = [
+            [
+                'directory', 'user',
+                '{"id":"7","primaryEmail":"' . $email . '",' .
+                 '"aliases":[]}'
+            ],
+            ['directory', 'users_alias', json_encode($aliasB)],
+            ['directory', 'users_alias', json_encode($aliasC)],
+        ];
         $fixturesClass->addFixtures($newFixtures);
 
         $newDir = new Directory('anyclient', $this->dataFile);
         $aliases = $newDir->users_aliases->listUsersAliases("7");
 
-        $results = array();
+        $results = [];
         foreach ($aliases['aliases'] as $nextAlias) {
             $results[] = json_encode($nextAlias);
         }
 
-        $expected = array(
+        $expected = [
             '{"alias":"users_alias7b@sil.org","etag":null,"id":"7","kind":null,' .
                '"primaryEmail":"user_test7@sil.org"}',
             '{"alias":"users_alias7c@sil.org","etag":null,"id":"7","kind":null,' .
                '"primaryEmail":null}',
-        );
+        ];
 
         $msg = " *** Bad returned Aliases";
         $this->assertEquals($expected, $results, $msg);
@@ -734,9 +798,9 @@ class DirectoryTest extends TestCase
         $email = "user_test1@sil.org";
 
         $alias = $this->getAliasFixture("users_alias7@sil.org", $email, "1");
-        $newFixtures = array(
-            array('directory', 'users_alias', json_encode($alias)),
-        );
+        $newFixtures = [
+            ['directory', 'users_alias', json_encode($alias)],
+        ];
 
         $fixturesClass->addFixtures($newFixtures);
 
@@ -749,14 +813,14 @@ class DirectoryTest extends TestCase
         $results = is_array($aliases['aliases']);
         $this->assertTrue($results, ' *** The aliases property is not an array');
 
-        $user_aliases = array();
+        $user_aliases = [];
 
         foreach ($aliases['aliases'] as $alias) {
             $user_aliases[] = $alias['alias'];
         }
 
         $results = $user_aliases;
-        $expected = array("users_alias2@sil.org", "users_alias7@sil.org");
+        $expected = ["users_alias2@sil.org", "users_alias7@sil.org"];
         $msg = " *** Bad returned Aliases";
         $this->assertEquals($expected, $results, $msg);
     }
@@ -773,15 +837,15 @@ class DirectoryTest extends TestCase
             "user_test1@sil.org",
             "1"
         );
-        $newFixtures = array(
-            array('directory', 'users_alias', json_encode($alias)),
-        );
+        $newFixtures = [
+            ['directory', 'users_alias', json_encode($alias)],
+        ];
         $fixturesClass->addFixtures($newFixtures);
 
         $newDir = new Directory('anyclient', $this->dataFile);
         
         $this->expectExceptionCode(201407101420);
-        $aliases = $newDir->users_aliases->listUsersAliases("no_user@sil.org");
+        $newDir->users_aliases->listUsersAliases("no_user@sil.org");
     }
 
     public function testUsersAliasesDelete()
@@ -795,9 +859,9 @@ class DirectoryTest extends TestCase
 
         $alias = $this->getAliasFixture("users_alias7@sil.org", $email, "1");
 
-        $newFixtures = array(
-            array('directory', 'users_alias', json_encode($alias)),
-        );
+        $newFixtures = [
+            ['directory', 'users_alias', json_encode($alias)],
+        ];
         $fixturesClass->addFixtures($newFixtures);
 
         $newDir = new Directory('anyclient', $this->dataFile);
@@ -811,19 +875,22 @@ class DirectoryTest extends TestCase
         $sqliteUtils = new SqliteUtils($this->dataFile);
         $results = $sqliteUtils->getData('directory', 'users_alias');
 
-        $expected = array(
-            array('id' => '6',
-                  'type' => 'directory',
-                  'class' => 'users_alias',
-                  'data' => '{"alias":"users_alias6@sil.org","etag":null,' .
-                            '"id":"1","kind":null,"primaryEmail":null}',
-            ),
-            array('id' => '7',
+        $expected = [
+            [
+                'id' => '6',
+                'type' => 'directory',
+                'class' => 'users_alias',
+                'data' => '{"alias":"users_alias6@sil.org","etag":null,' .
+                           '"id":"1","kind":null,"primaryEmail":null}',
+            ],
+            [
+                'id' => '7',
                 'type' => 'directory',
                 'class' => 'users_alias',
                 'data' => '{"alias":"users_alias7@sil.org","etag":null,' .
-                          '"id":"1","kind":null,"primaryEmail":"' . $email . '"}'),
-        );
+                           '"id":"1","kind":null,"primaryEmail":"' . $email . '"}'
+            ],
+        ];
         $msg = " *** Mismatching users_aliases in db";
         $this->assertEquals($expected, $results, $msg);
     }


### PR DESCRIPTION
### Fixed ###
* Add an alias, like Google, when renaming the primary email address

### Added ###
* Test coverage for fixed code