### PR TITLE
Add simplistic implementation of `members->insert()`

### DIFF
--- a/SilMock/Google/Service/Directory.php
+++ b/SilMock/Google/Service/Directory.php
@@ -3,6 +3,7 @@
 namespace SilMock\Google\Service;
 
 use SilMock\Google\Service\Directory\Asps;
+use SilMock\Google\Service\Directory\Members;
 use SilMock\Google\Service\Directory\Tokens;
 use SilMock\Google\Service\Directory\UsersResource;
 use SilMock\Google\Service\Directory\UsersAliasesResource;
@@ -12,6 +13,7 @@ use SilMock\Google\Service\Directory\Resource\TwoStepVerification;
 class Directory
 {
     public $asps;
+    public Members $members;
     public $tokens;
     public $users;
     public $users_aliases;
@@ -28,6 +30,7 @@ class Directory
     public function __construct($client, $dbFile = null)
     {
         $this->asps = new Asps($dbFile);
+        $this->members = new Members($dbFile);
         $this->tokens = new Tokens($dbFile);
         $this->users = new UsersResource($dbFile);
         $this->users_aliases = new UsersAliasesResource($dbFile);

--- a/SilMock/Google/Service/Directory/Members.php
+++ b/SilMock/Google/Service/Directory/Members.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SilMock\Google\Service\Directory;
+
+use Exception;
+use Google\Service\Directory\Member;
+use SilMock\Google\Service\DbClass;
+
+class Members extends DbClass
+{
+    public function __construct($dbFile = null)
+    {
+        parent::__construct($dbFile, 'directory', 'members');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function insert(string $groupKey, Member $postBody)
+    {
+        $dataAsJson = json_encode([
+            'groupKey' => $groupKey,
+            'member' => get_object_vars($postBody),
+        ]);
+        $sqliteUtils = $this->getSqliteUtils();
+        $sqliteUtils->recordData(
+            $this->dataType,
+            $this->dataClass,
+            $dataAsJson
+        );
+
+        $newMember = new Member();
+        ObjectUtils::initialize($newMember, $postBody);
+
+        return $newMember;
+    }
+}


### PR DESCRIPTION
### Added
- Add simplistic implementation of `members->insert()`

---

**NOTE:**
- This does not fully implement `insert()`. It merely does enough for our use case to work. For example, it does not detect when a user is already a member of a group and throw a 409 Conflict.