### PR TITLE
Release 2.1.0 - Add `members->insert()` mock

### DIFF
--- a/actions-services.yml
+++ b/actions-services.yml
@@ -3,4 +3,3 @@ services:
     google-api-php-client-mock:
         build: .
         working_dir: /data
-        command: "bash -c \"cd /data/SilMock/tests; ./phpunit\""


### PR DESCRIPTION
### Added
- Add simplistic implementation of `members->insert()`

---

**NOTE:**
- This does not fully implement `insert()`. It merely does enough for our use case to work. For example, it does not detect when a user is already a member of a group and throw a 409 Conflict.