### PR TITLE
Use boolean default values for isEnforcedIn2Sv and isEnrolledIn2Sv

### DIFF
--- a/SilMock/Google/Service/Directory/UsersResource.php
+++ b/SilMock/Google/Service/Directory/UsersResource.php
@@ -165,8 +165,8 @@ class UsersResource extends DbClass
             'lastLoginTime' => $currentDateTime->format('c'),
             'creationTime' => $currentDateTime->format('c'),
             'agreedToTerms' => false,
-            'isEnforcedIn2Sv' => 'false',
-            'isEnrolledIn2Sv' => 'false',
+            'isEnforcedIn2Sv' => false,
+            'isEnrolledIn2Sv' => false,
         );
 
         // array_merge will not work, since $postBody is an object which only
@@ -256,10 +256,10 @@ class UsersResource extends DbClass
             }
         }
         if (!isset($dbUserProps['isEnforcedIn2Sv'])) {
-            $dbUserProps['isEnforcedIn2Sv'] = 'false';
+            $dbUserProps['isEnforcedIn2Sv'] = false;
         }
         if (!isset($dbUserProps['isEnrolledIn2Sv'])) {
-            $dbUserProps['isEnrolledIn2Sv'] = 'false';
+            $dbUserProps['isEnrolledIn2Sv'] = false;
         }
 
         // Delete the user's old aliases before adding the new ones


### PR DESCRIPTION
### Fixed
- Use boolean default values for `isEnforcedIn2Sv` and `isEnrolledIn2Sv`