### PR TITLE
Release 2.13.2: Fix aliases data type in group.get results

### DIFF
--- a/SilMock/Google/Service/Directory/Resource/Groups.php
+++ b/SilMock/Google/Service/Directory/Resource/Groups.php
@@ -58,8 +58,10 @@ class Groups extends DbClass
         }
         if ($matchedGroup !== null) {
             $mockGroupsAliasesObject = new GroupsAliases($this->dbFile);
-            $aliases = $mockGroupsAliasesObject->listGroupsAliases($matchedGroup->getEmail());
-            $matchedGroup->setAliases($aliases->getAliases());
+            $aliasesObject = $mockGroupsAliasesObject->listGroupsAliases($matchedGroup->getEmail());
+            $arrayOfAliasOjbects = $aliasesObject->getAliases();
+            $aliases = array_map(function (GoogleDirectory_GroupAlias $alias) { return $alias->getAlias(); }, $arrayOfAliasOjbects);
+            $matchedGroup->setAliases($aliases);
         }
         return $matchedGroup;
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "silinternational/google-api-php-client-mock",
-    "version": "2.13.1",
+    "version": "2.13.2",
     "description": "Attempting to create an intelligent mock of the Google API PHP Client for unit and functional testing.",
     "type": "library",
     "keywords": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98589aa7e195a743dcf2387f4ae0d570",
+    "content-hash": "6a6776cd80056ba0e3e3e1e8ae7f6e7d",
     "packages": [
         {
             "name": "firebase/php-jwt",


### PR DESCRIPTION
### Fix
* return array of strings and not Alias objects for group.get's aliases property