### PR TITLE
Fix alias related bugs

### DIFF
--- a/SilMock/Google/Service/Directory/Resource/Groups.php
+++ b/SilMock/Google/Service/Directory/Resource/Groups.php
@@ -64,7 +64,12 @@ class Groups extends DbClass
             $mockGroupsAliasesObject = new GroupsAliases($this->dbFile);
             $aliasesObject = $mockGroupsAliasesObject->listGroupsAliases($matchedGroup->getEmail());
             $arrayOfAliasObjects = $aliasesObject->getAliases();
-            $aliases = array_map(function (GoogleDirectory_GroupAlias $alias) { return $alias->getAlias(); }, $arrayOfAliasObjects);
+            $aliases = array_map(
+                function (GoogleDirectory_GroupAlias $alias) {
+                    return $alias->getAlias();
+                },
+                $arrayOfAliasObjects
+            );
             $matchedGroup->setAliases($aliases);
         }
         return $matchedGroup;
@@ -134,7 +139,12 @@ class Groups extends DbClass
             $mockGroupsAliasesObject = new GroupsAliases($this->dbFile);
             $aliasesObject = $mockGroupsAliasesObject->listGroupsAliases($group->getEmail());
             $aliasesObjectArray = $aliasesObject->getAliases();
-            $aliases = array_map(function (GoogleDirectory_GroupAlias $alias) { return $alias->getAlias(); }, $aliasesObjectArray);
+            $aliases = array_map(
+                function (GoogleDirectory_GroupAlias $alias) {
+                    return $alias->getAlias();
+                },
+                $aliasesObjectArray
+            );
             $group->setAliases($aliases);
         }
         return $groups;

--- a/SilMock/Google/Service/Directory/UsersAliasesResource.php
+++ b/SilMock/Google/Service/Directory/UsersAliasesResource.php
@@ -223,6 +223,5 @@ class UsersAliasesResource extends DbClass
                 );
             }
         }
-
     }
 }

--- a/SilMock/Google/Service/Directory/UsersAliasesResource.php
+++ b/SilMock/Google/Service/Directory/UsersAliasesResource.php
@@ -42,8 +42,35 @@ class UsersAliasesResource extends DbClass
             throw new Exception(self::ACCOUNT_DOESNT_EXIST . $userKey, 201407101645);
         }
 
-        // Get all the aliases for that user
         $sqliteUtils = new SqliteUtils($this->dbFile);
+        // Get all the user records for that user
+        $userRecords = $sqliteUtils->getAllRecordsByDataKey(
+            $this->dataType,
+            'users',
+            $key,
+            $userKey,
+        );
+        // Check the data of each alias and when there is a match,
+        // delete that alias and return true
+        foreach ($userRecords as $userRecord) {
+            $userData = json_decode($userRecord['data'], true);
+            if (is_array($userData['aliases'])) {
+                $userRecordAliases = [];
+                foreach ($userData['aliases'] as $userAlias) {
+                    if (strcasecmp($userAlias, $alias) !== 0) {
+                        $userRecordAliases[] = $alias;
+                    }
+                }
+                $userData['aliases'] = $userRecordAliases;
+                $userRecordData = json_encode($userData, JSON_PRETTY_PRINT);
+                $sqliteUtils->updateRecordById(
+                    intval($userRecord['id']),
+                    $userRecordData
+                );
+            }
+        }
+
+        // Get all the aliases for that user
         $aliases =  $sqliteUtils->getAllRecordsByDataKey(
             $this->dataType,
             $this->dataClass,

--- a/SilMock/Google/Service/Directory/UsersAliasesResource.php
+++ b/SilMock/Google/Service/Directory/UsersAliasesResource.php
@@ -43,6 +43,7 @@ class UsersAliasesResource extends DbClass
         }
 
         $sqliteUtils = new SqliteUtils($this->dbFile);
+
         // Get all the user records for that user
         $userRecords = $sqliteUtils->getAllRecordsByDataKey(
             $this->dataType,

--- a/SilMock/Google/Service/Directory/UsersAliasesResource.php
+++ b/SilMock/Google/Service/Directory/UsersAliasesResource.php
@@ -50,25 +50,8 @@ class UsersAliasesResource extends DbClass
             $key,
             $userKey,
         );
-        // Check the data of each alias and when there is a match,
-        // delete that alias and return true
-        foreach ($userRecords as $userRecord) {
-            $userData = json_decode($userRecord['data'], true);
-            if (is_array($userData['aliases'])) {
-                $userRecordAliases = [];
-                foreach ($userData['aliases'] as $userAlias) {
-                    if (strcasecmp($userAlias, $alias) !== 0) {
-                        $userRecordAliases[] = $alias;
-                    }
-                }
-                $userData['aliases'] = $userRecordAliases;
-                $userRecordData = json_encode($userData, JSON_PRETTY_PRINT);
-                $sqliteUtils->updateRecordById(
-                    intval($userRecord['id']),
-                    $userRecordData
-                );
-            }
-        }
+
+        $this->makeUserRecordAliasesMatch($userRecords, $alias, $sqliteUtils);
 
         // Get all the aliases for that user
         $aliases =  $sqliteUtils->getAllRecordsByDataKey(
@@ -217,5 +200,29 @@ class UsersAliasesResource extends DbClass
         $newUsersAliases = new \Google_Service_Directory_Aliases();
         $newUsersAliases->setAliases($foundAliases);
         return $newUsersAliases;
+    }
+
+    private function makeUserRecordAliasesMatch(array $userRecords, string $alias, SqliteUtils $sqliteUtils): void
+    {
+        // Check the data of each alias and when there is a match,
+        // delete that alias and return true
+        foreach ($userRecords as $userRecord) {
+            $userData = json_decode($userRecord['data'], true);
+            if (is_array($userData['aliases'])) {
+                $userRecordAliases = [];
+                foreach ($userData['aliases'] as $userAlias) {
+                    if (strcasecmp($userAlias, $alias) !== 0) {
+                        $userRecordAliases[] = $alias;
+                    }
+                }
+                $userData['aliases'] = $userRecordAliases;
+                $userRecordData = json_encode($userData, JSON_PRETTY_PRINT);
+                $sqliteUtils->updateRecordById(
+                    intval($userRecord['id']),
+                    $userRecordData
+                );
+            }
+        }
+
     }
 }

--- a/SilMock/Google/Service/Directory/UsersResource.php
+++ b/SilMock/Google/Service/Directory/UsersResource.php
@@ -66,6 +66,7 @@ class UsersResource extends DbClass
         $newName = new \Google_Service_Directory_UserName();
         ObjectUtils::initialize($newName, $nameArray);
         $newUser->setName($newName);
+        $userKey = $decodedData['primaryEmail'] ?? $userKey; // correct for aliases.
 
         // find its aliases in the database and populate its aliases property
         $aliases = $this->getAliasesForUser($userKey);
@@ -77,6 +78,8 @@ class UsersResource extends DbClass
             }
 
             $newUser->aliases = $foundAliases;
+        } else {
+            $newUser->aliases = [];
         }
 
         return $newUser;

--- a/SilMock/Google/Service/Groupssettings/Resource/Groups.php
+++ b/SilMock/Google/Service/Groupssettings/Resource/Groups.php
@@ -73,8 +73,11 @@ class Groups extends DbClass
         return $this->get($postBody->getEmail());
     }
 
-    public function update(string $groupKey, GoogleGroupsSettings_Groups $postBody, $optParams = []): GoogleGroupsSettings_Groups
-    {
+    public function update(
+        string $groupKey,
+        GoogleGroupsSettings_Groups $postBody,
+        $optParams = []
+    ): GoogleGroupsSettings_Groups {
         if (! $this->doGroupsSettingsExist($postBody->getEmail())) {
             throw new Exception("Group Settings for '{$groupKey}' does not exist.");
         }

--- a/SilMock/Google/Service/Groupssettings/Resource/Groups.php
+++ b/SilMock/Google/Service/Groupssettings/Resource/Groups.php
@@ -44,7 +44,6 @@ class Groups extends DbClass
         $groupRecords = $this->getRecords();
         foreach ($groupRecords as $groupRecord) {
             $groupRecordData = json_decode($groupRecord['data'], true);
-            echo "CHECKING " . $groupKey . " FOR: " . $groupRecordData['email'] . "\n";
             if (strcasecmp($groupKey, $groupRecordData['email']) === 0) {
                 $matchingData = $groupRecordData;
             }

--- a/SilMock/tests/Google/Service/Directory/Resource/GroupsTest.php
+++ b/SilMock/tests/Google/Service/Directory/Resource/GroupsTest.php
@@ -84,7 +84,7 @@ class GroupsTest extends TestCase
         $group->setAliases([self::GROUP_ALIAS_ADDRESS . 'update-change']);
         $updatedGroup = $mockGoogleServiceDirectory->groups->update($group->getEmail(), $group);
         self::assertTrue($updatedGroup instanceof GoogleDirectory_Group);
-        self::assertEmpty($updatedGroup->getAliases(),  "Expecting no group aliases changed by group.update");
+        self::assertEmpty($updatedGroup->getAliases(), "Expecting no group aliases changed by group.update");
     }
 
     protected function deleteTestSetup()
@@ -214,7 +214,9 @@ class GroupsTest extends TestCase
             );
         }
         try {
-            $groupAliases = $mockGoogleServiceDirectory->groups_aliases->listGroupsAliases(self::GROUP_EMAIL_ADDRESS . 'delete');
+            $groupAliases = $mockGoogleServiceDirectory->groups_aliases->listGroupsAliases(
+                self::GROUP_EMAIL_ADDRESS . 'delete'
+            );
             self::assertEmpty(
                 $groupAliases->getAliases(),
                 'Was expecting the group aliases to be deleted by name, but found something'

--- a/SilMock/tests/Google/Service/DirectoryTest.php
+++ b/SilMock/tests/Google/Service/DirectoryTest.php
@@ -87,8 +87,8 @@ class DirectoryTest extends TestCase
 
         $expected = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
-            "id" => 999991,
+            "hashFunction" => "SHA-512",
+            "id" => '999991',
             "password" => "testP4ss",
             "primaryEmail" => "user_test1@sil.org",
             "suspended" => false,
@@ -108,8 +108,8 @@ class DirectoryTest extends TestCase
 
         $expected = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
-            "id" => 999991,
+            "hashFunction" => "SHA-512",
+            "id" => '999991',
             "password" => "testP4ss",
             "primaryEmail" => "user_test1@sil.org",
             "suspended" => false,
@@ -129,8 +129,8 @@ class DirectoryTest extends TestCase
         $results =  $this->getProperties($newUser);
         $expected = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
-            "id" => 999991,
+            "hashFunction" => "SHA-512",
+            "id" => '999991',
             "password" => "testP4ss",
             "primaryEmail" => "user_test1@sil.org",
             "suspended" => false,
@@ -164,7 +164,7 @@ class DirectoryTest extends TestCase
     public function getFixtures(): array
     {
         $user4Data = '{"changePasswordAtNextLogin":false,' .
-            '"hashFunction":"SHA-1",' .
+            '"hashFunction":"SHA-512",' .
             '"id":"999991","password":"testP4ss",' .
             '"primaryEmail":"user_test4@sil.org",' .
             '"isEnforcedIn2Sv":false,' .
@@ -216,14 +216,14 @@ class DirectoryTest extends TestCase
 
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
-            "id" => 999991,
+            "hashFunction" => "SHA-512",
+            "id" => '999991',
             "password" => "testP4ss",
             "primaryEmail" => $primaryEmail,
             "suspended" => false,
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
-            "aliases" => null,
+            "aliases" => [],
         ];
 
         $fixtures = $this->getFixtures();
@@ -247,14 +247,14 @@ class DirectoryTest extends TestCase
 
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
+            "hashFunction" => "SHA-512",
             "id" => $userId,
             "password" => "testP4ss",
             "primaryEmail" => "user_test4@sil.org",
             "suspended" => false,
             "isEnforcedIn2Sv" => false,
             "isEnrolledIn2Sv" => true,
-            "aliases" => null,
+            "aliases" => [],
         ];
 
         $fixtures = $this->getFixtures();
@@ -282,7 +282,7 @@ class DirectoryTest extends TestCase
 
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
+            "hashFunction" => "SHA-512",
             "id" => $userId,
             "password" => "testP4ss",
             "primaryEmail" => $email,
@@ -352,8 +352,8 @@ class DirectoryTest extends TestCase
 
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
-            "id" => 999991,
+            "hashFunction" => "SHA-512",
+            "id" => '999991',
             "password" => "testP4ss",
             "primaryEmail" => $primaryEmail,
             "suspended" => false,
@@ -388,7 +388,7 @@ class DirectoryTest extends TestCase
 
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
+            "hashFunction" => "SHA-512",
             "id" => $userId,
             "password" => "testP4ss",
             "primaryEmail" => "user_test4@sil.org",
@@ -425,7 +425,7 @@ class DirectoryTest extends TestCase
 
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
+            "hashFunction" => "SHA-512",
             "id" => $userId,
             "password" => "testP4ss",
             "primaryEmail" => $newEmailAddress,
@@ -467,8 +467,8 @@ class DirectoryTest extends TestCase
 
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
-            "id" => 999991,
+            "hashFunction" => "SHA-512",
+            "id" => '999991',
             "password" => "testP4ss",
             "primaryEmail" => $primaryEmail,
             "suspended" => false,
@@ -513,8 +513,8 @@ class DirectoryTest extends TestCase
         // Different aliases
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
-            "id" => 999991,
+            "hashFunction" => "SHA-512",
+            "id" => '999991',
             "password" => "testP4ss",
             "primaryEmail" => $primaryEmail,
             "suspended" => false,
@@ -550,7 +550,7 @@ class DirectoryTest extends TestCase
 
         $userData = [
             "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-1",
+            "hashFunction" => "SHA-512",
             "id" => $userId,
             "password" => "testP4ss",
             "primaryEmail" => "user_test4@sil.org",
@@ -621,7 +621,7 @@ class DirectoryTest extends TestCase
         $fixturesClass = new GoogleFixtures($this->dataFile);
         $fixturesClass->removeAllFixtures();
 
-        $userId = 999991;
+        $userId = '999991';
 
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);

--- a/SilMock/tests/Google/Service/DirectoryTest.php
+++ b/SilMock/tests/Google/Service/DirectoryTest.php
@@ -18,6 +18,7 @@ class DirectoryTest extends TestCase
     use SampleUser;
 
     public string $dataFile = DATAFILE2;
+    public string $userId = '999991';
 
     public function getProperties($object, $propKeys = null): array
     {
@@ -88,7 +89,7 @@ class DirectoryTest extends TestCase
         $expected = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => '999991',
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => "user_test1@sil.org",
             "suspended" => false,
@@ -106,18 +107,7 @@ class DirectoryTest extends TestCase
         $dataObj = json_decode($lastDataEntry['data']);
         $results = $this->getProperties($dataObj);
 
-        $expected = [
-            "changePasswordAtNextLogin" => false,
-            "hashFunction" => "SHA-512",
-            "id" => '999991',
-            "password" => "testP4ss",
-            "primaryEmail" => "user_test1@sil.org",
-            "suspended" => false,
-            "isEnforcedIn2Sv" => false,
-            "isEnrolledIn2Sv" => true,
-            "aliases" => [],
-        ];
-
+        // $expected is the same as above
         $msg = " *** Bad data from sqlite database";
         $this->assertEquals($expected, $results, $msg);
     }
@@ -130,7 +120,7 @@ class DirectoryTest extends TestCase
         $expected = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => '999991',
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => "user_test1@sil.org",
             "suspended" => false,
@@ -217,7 +207,7 @@ class DirectoryTest extends TestCase
         $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => '999991',
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => $primaryEmail,
             "suspended" => false,
@@ -243,12 +233,10 @@ class DirectoryTest extends TestCase
         $fixturesClass = new GoogleFixtures($this->dataFile);
         $fixturesClass->removeAllFixtures();
 
-        $userId = '999991';
-
         $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => $userId,
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => "user_test4@sil.org",
             "suspended" => false,
@@ -261,7 +249,7 @@ class DirectoryTest extends TestCase
         $fixturesClass->addFixtures($fixtures);
 
         $newDir = new Directory('anyclient', $this->dataFile);
-        $newUser = $newDir->users->get($userId);
+        $newUser = $newDir->users->get($this->userId);
 
         $results = $this->getProperties($newUser);
         $expected = $userData;
@@ -277,13 +265,12 @@ class DirectoryTest extends TestCase
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
 
-        $userId = '999991';
         $email = "user_test4@sil.org";
 
         $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => $userId,
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => $email,
             "suspended" => false,
@@ -353,7 +340,7 @@ class DirectoryTest extends TestCase
         $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => '999991',
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => $primaryEmail,
             "suspended" => false,
@@ -384,12 +371,10 @@ class DirectoryTest extends TestCase
         $fixturesClass = new GoogleFixtures($this->dataFile);
         $fixturesClass->removeAllFixtures();
 
-        $userId = '999991';
-
         $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => $userId,
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => "user_test4@sil.org",
             "suspended" => false,
@@ -405,8 +390,8 @@ class DirectoryTest extends TestCase
         ObjectUtils::initialize($newUser, $userData);
 
         $newDir = new Directory('anyclient', $this->dataFile);
-        $newDir->users->update($userId, $newUser);
-        $newUser = $newDir->users->get($userId);
+        $newDir->users->update($this->userId, $newUser);
+        $newUser = $newDir->users->get($this->userId);
 
         $results = $this->getProperties($newUser);
         $expected = $userData;
@@ -419,14 +404,13 @@ class DirectoryTest extends TestCase
         $fixturesClass = new GoogleFixtures($this->dataFile);
         $fixturesClass->removeAllFixtures();
 
-        $userId = '999991';
         $oldEmailAddress = 'user_test4@sil.org';
         $newEmailAddress = 'user_test4a@sil.org';
 
         $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => $userId,
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => $newEmailAddress,
             "suspended" => false,
@@ -442,8 +426,8 @@ class DirectoryTest extends TestCase
         ObjectUtils::initialize($newUser, $userData);
 
         $newDir = new Directory('anyclient', $this->dataFile);
-        $newDir->users->update($userId, $newUser);
-        $newUser = $newDir->users->get($userId);
+        $newDir->users->update($this->userId, $newUser);
+        $newUser = $newDir->users->get($this->userId);
 
         $results = $this->getProperties($newUser);
         $expected = $userData;
@@ -454,7 +438,7 @@ class DirectoryTest extends TestCase
         // Attempt to get the user by the alias, after updating the primary email address
         $newUser = $newDir->users->get($oldEmailAddress);
         $results = $this->getProperties($newUser);
-        $msg = " *** Bad user data returned";
+        // $msg is as above
         $this->assertEquals($expected, $results, $msg);
     }
 
@@ -468,7 +452,7 @@ class DirectoryTest extends TestCase
         $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => '999991',
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => $primaryEmail,
             "suspended" => false,
@@ -514,7 +498,7 @@ class DirectoryTest extends TestCase
         $userData = [
             "changePasswordAtNextLogin" => false,
             "hashFunction" => "SHA-512",
-            "id" => '999991',
+            "id" => $this->userId,
             "password" => "testP4ss",
             "primaryEmail" => $primaryEmail,
             "suspended" => false,
@@ -621,13 +605,11 @@ class DirectoryTest extends TestCase
         $fixturesClass = new GoogleFixtures($this->dataFile);
         $fixturesClass->removeAllFixtures();
 
-        $userId = '999991';
-
         $fixtures = $this->getFixtures();
         $fixturesClass->addFixtures($fixtures);
 
         $newDir = new Directory('anyclient', $this->dataFile);
-        $newDir->users->delete($userId);
+        $newDir->users->delete($this->userId);
 
         $sqliteClass = new SqliteUtils($this->dataFile);
         $results = $sqliteClass->getData('', '');

--- a/SilMock/tests/Google/Service/SampleUser.php
+++ b/SilMock/tests/Google/Service/SampleUser.php
@@ -15,8 +15,8 @@ trait SampleUser
         $fixturesClass->removeAllFixtures();
         $newUser = new Google_Service_Directory_User();
         $newUser->changePasswordAtNextLogin = false; // bool
-        $newUser->hashFunction = "SHA-1"; // string
-        $newUser->id = 999991; // int???
+        $newUser->hashFunction = "SHA-512"; // string
+        $newUser->id = '999991'; // using string
         $newUser->password = 'testP4ss'; // string
         $newUser->primaryEmail = 'user_test1@sil.org'; // string email
         $newUser->suspended = false; // bool


### PR DESCRIPTION
### Fix
* Keep user_aliases data consistent with the aliases array in user
* Use the alias email address as the user key if lookup was found based on aliases
* Remove group settings debugging messages