### PR TITLE
Add isMailboxSetup to users.get

### DIFF
--- a/SilMock/Google/Service/Directory/UsersResource.php
+++ b/SilMock/Google/Service/Directory/UsersResource.php
@@ -81,6 +81,7 @@ class UsersResource extends DbClass
         } else {
             $newUser->aliases = [];
         }
+        $newUser->isMailboxSetup = true;
 
         return $newUser;
     }


### PR DESCRIPTION
It always returns true. Needed a quick solution to the infinite loop problem posed by checking isMailboxSetup when creating an account in MailAdmin.